### PR TITLE
Notice: Undefined variable: nid in NodeEntityFieldQuery->excludeNode()

### DIFF
--- a/efq_example.module
+++ b/efq_example.module
@@ -175,8 +175,8 @@ class NodeEntityFieldQuery extends EntityFieldQuery {
   /**
    * If we're on a node, and if the entity_type is node, exclude the local node from the query
    */
-  public function excludeNode($nid) {
-    if (!$nid) {
+  public function excludeNode($nid = '') {
+    if ($nid$nid = '') {
       $object = menu_get_object();
       $nid = $object->nid;
     }

--- a/efq_example.module
+++ b/efq_example.module
@@ -176,7 +176,7 @@ class NodeEntityFieldQuery extends EntityFieldQuery {
    * If we're on a node, and if the entity_type is node, exclude the local node from the query
    */
   public function excludeNode($nid = '') {
-    if ($nid$nid = '') {
+    if ($nid = '') {
       $object = menu_get_object();
       $nid = $object->nid;
     }


### PR DESCRIPTION
Fixed these errors:
Warning: Missing argument 1 for NodeEntityFieldQuery::excludeNode()
and
Notice: Undefined variable: nid in NodeEntityFieldQuery->excludeNode()
